### PR TITLE
Fix truncation from 64-bit to 32-bit in compressed_size_sorted and select_sorted

### DIFF
--- a/test.cc
+++ b/test.cc
@@ -47,7 +47,7 @@ run_select_test(const std::vector<typename Traits::type> &plain,
   Timer<boost::chrono::high_resolution_clock> t;
   for (int l = 0; l < loops; l++) {
     for (uint32_t i = 0; i < plain.size(); i += 1 + plain.size() / 100) {
-      uint32_t v = Traits::select(&z[0], z.size(), i);
+      typename Traits::type v = Traits::select(&z[0], z.size(), i);
       assert(plain[i] == v);
     }
   }
@@ -106,7 +106,7 @@ run_tests(size_t length)
   std::vector<typename Traits::type> out(length);
 
   for (size_t i = 0; i < length; i++)
-    plain.push_back(i * 7);
+    plain.push_back(Traits::make_plain_value(i));
 
   // compress the data
   run_compression_test<Traits>(plain, z);
@@ -127,6 +127,10 @@ run_tests(size_t length)
 struct Sorted32Traits {
   typedef uint32_t type;
   static constexpr const char *name = "Sorted32";
+
+  static type make_plain_value(size_t i) {
+    return i * 7;
+  }
 
   static size_t compress(const type *in, uint8_t *out, size_t length) {
     return vbyte_compress_sorted32(in, out, 0, length);
@@ -158,6 +162,10 @@ struct Sorted64Traits {
   typedef uint64_t type;
   static constexpr const char *name = "Sorted64";
 
+  static type make_plain_value(size_t i) {
+    return i * i;
+  }
+
   static size_t compress(const type *in, uint8_t *out, size_t length) {
     return vbyte_compress_sorted64(in, out, 0, length);
   }
@@ -187,6 +195,10 @@ struct Sorted64Traits {
 struct Unsorted32Traits {
   typedef uint32_t type;
   static constexpr const char *name = "Unsorted32";
+
+  static type make_plain_value(size_t i) {
+    return i * 7;
+  }
 
   static size_t compress(const type *in, uint8_t *out, size_t length) {
     return vbyte_compress_unsorted32(in, out, length);
@@ -218,6 +230,10 @@ struct Unsorted32Traits {
 struct Unsorted64Traits {
   typedef uint64_t type;
   static constexpr const char *name = "Unsorted64";
+
+  static type make_plain_value(size_t i) {
+    return i * i;
+  }
 
   static size_t compress(const type *in, uint8_t *out, size_t length) {
     return vbyte_compress_unsorted64(in, out, length);

--- a/vbyte.cc
+++ b/vbyte.cc
@@ -362,7 +362,7 @@ compressed_size(uint64_t value)
 
 template<typename T>
 static inline size_t
-compressed_size_sorted(const T *in, size_t length, uint32_t previous)
+compressed_size_sorted(const T *in, size_t length, T previous)
 {
   size_t size = 0;
   const T *end = in + length;
@@ -447,7 +447,7 @@ uncompress_sorted(const uint8_t *in, T *out, T previous, size_t length)
 
 template<typename T>
 static inline T
-select_sorted(const uint8_t *in, uint32_t previous, size_t index)
+select_sorted(const uint8_t *in, T previous, size_t index)
 {
   for (size_t i = 0; i <= index; i++) {
     T current;


### PR DESCRIPTION
### Problem

Compiling on clang gave the following warnings:

```
vbyte.cc:515:52: warning: implicit conversion loses integer precision: 'uint64_t' (aka 'unsigned long long') to 'uint32_t' (aka 'unsigned int')
      [-Wshorten-64-to-32]
  return vbyte::compressed_size_sorted(in, length, previous);
         ~~~~~                                     ^~~~~~~~
vbyte.cc:607:45: warning: implicit conversion loses integer precision: 'uint64_t' (aka 'unsigned long long') to 'uint32_t' (aka 'unsigned int')
      [-Wshorten-64-to-32]
  return vbyte::select_sorted<uint64_t>(in, previous, index);
         ~~~~~                              ^~~~~~~~
vbyte.cc:372:16: warning: implicit conversion loses integer precision: 'const unsigned long long' to 'uint32_t' (aka 'unsigned int') [-Wshorten-64-to-32]
    previous = *in;
             ~ ^~~
vbyte.cc:515:17: note: in instantiation of function template specialization 'vbyte::compressed_size_sorted<unsigned long long>' requested here
  return vbyte::compressed_size_sorted(in, length, previous);
```

### Solution

Two commits:

1. Add a test that exercises the problem. There was another truncation to `uint32_t` in the test set that masked the problem, and the values in the `plain` vector were not actually large enough to overflow a `uint32_t`.

2. Fix the problem by changing the template functions to use the `T` type for `previous` instead of hard coding `uint32_t`.

PS: Thanks for this great library. It is super useful!