### PR TITLE
Add `libvbyte in other langauges` section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,4 +96,6 @@ For further information, see
 * Jeff Plaisance, Nathan Kurz, Daniel Lemire, Vectorized VByte Decoding, International Symposium on Web Algorithms 2015, 2015. http://arxiv.org/abs/1503.07387
 * Wayne Xin Zhao, Xudong Zhang, Daniel Lemire, Dongdong Shan, Jian-Yun Nie, Hongfei Yan, Ji-Rong Wen, A General SIMD-based Approach to Accelerating Compression Algorithms, ACM Transactions on Information Systems 33 (3), 2015. http://arxiv.org/abs/1502.01916
 
-
+libvbyte in other langauges
+------------------------
+- Zig bindings ([repository](https://github.com/steelcake/libvbyte-zig))


### PR DESCRIPTION
Hey, thanks for creating this library. I want to use it in zig so I created bindings for it [here](https://github.com/steelcake/libvbyte-zig).

Also added fuzz tests in that repo.

Added a `in other langauges` to the README in this PR, similar to [this](https://github.com/fast-pack/streamvbyte?tab=readme-ov-file#stream-vbyte-in-other-languages)

